### PR TITLE
Replace deprecated media_access with file_entity_access.

### DIFF
--- a/includes/MediaMediaHavenBrowser.inc
+++ b/includes/MediaMediaHavenBrowser.inc
@@ -16,7 +16,7 @@ class MediaMediaHavenBrowser extends MediaBrowserPlugin {
    * Implements MediaBrowserPluginInterface::access().
    */
   public function access($account = NULL) {
-    return media_access('create', $account);
+    return file_entity_access('create', $account);
   }
 
   /**


### PR DESCRIPTION
media_access is deprecated and should not be used anymore. The function is actually removed in the latest version of the media module: https://www.drupal.org/node/2153459