### PR TITLE
When calling the API we get a 404 service not found.

### DIFF
--- a/includes/media_mediahaven.variables.inc
+++ b/includes/media_mediahaven.variables.inc
@@ -11,5 +11,5 @@
  */
 define('MEDIA_MEDIAHAVEN_NAMESPACE', 'media_mediahaven_');
 define('MEDIA_MEDIAHAVEN_PAGER', '25');
-define('MEDIA_MEDIAHAVEN_RESTPOINT', '/mediahaven-rest-api/resources/');
+define('MEDIA_MEDIAHAVEN_RESTPOINT', '/mediahaven-rest-api/resources');
 


### PR DESCRIPTION
When calling the API we get a 404 service not found. In the request uri there is a double /. When removed the call works.